### PR TITLE
feat(backend) implementacion de suscripciones a creadores

### DIFF
--- a/src/main/java/com/Profpost/api/SubscriptionController.java
+++ b/src/main/java/com/Profpost/api/SubscriptionController.java
@@ -1,0 +1,29 @@
+package com.Profpost.api;
+
+import com.Profpost.dto.SubscriptionDTO;
+import com.Profpost.dto.SubscriptionResponseDTO;
+import com.Profpost.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/subscription")
+public class SubscriptionController {
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping
+    public ResponseEntity<SubscriptionResponseDTO> subscribe(@RequestBody SubscriptionDTO subscriptionDTO) {
+        SubscriptionResponseDTO response = subscriptionService.subscribe(subscriptionDTO);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{subscriptionId}")
+    public ResponseEntity<SubscriptionResponseDTO> unsubscribe(@PathVariable Integer subscriptionId) {
+        SubscriptionResponseDTO response = subscriptionService.unsubscribe(subscriptionId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/Profpost/dto/SubscriptionDTO.java
+++ b/src/main/java/com/Profpost/dto/SubscriptionDTO.java
@@ -1,0 +1,22 @@
+package com.Profpost.dto;
+
+public class SubscriptionDTO {
+    private Integer user_id;
+    private Integer creator_id;
+
+    public Integer getUser_id() {
+        return user_id;
+    }
+
+    public void setUser_id(Integer user_id) {
+        this.user_id = user_id;
+    }
+
+    public Integer getCreator_id() {
+        return creator_id;
+    }
+
+    public void setCreator_id(Integer creator_id) {
+        this.creator_id = creator_id;
+    }
+}

--- a/src/main/java/com/Profpost/dto/SubscriptionResponseDTO.java
+++ b/src/main/java/com/Profpost/dto/SubscriptionResponseDTO.java
@@ -1,0 +1,12 @@
+package com.Profpost.dto;
+
+import lombok.Data;
+
+@Data
+public class SubscriptionResponseDTO {
+    private Integer subscriptionId;
+    private Integer userId;
+    private Integer creatorId;
+    private String status;
+    private String message;
+}

--- a/src/main/java/com/Profpost/model/entity/Plan.java
+++ b/src/main/java/com/Profpost/model/entity/Plan.java
@@ -22,5 +22,5 @@ public class Plan {
 
     @ManyToOne
     @JoinColumn(name = "suscription_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_plan_suscription"))
-    private Suscription suscription;
+    private Subscription suscription;
 }

--- a/src/main/java/com/Profpost/model/entity/Pucharse.java
+++ b/src/main/java/com/Profpost/model/entity/Pucharse.java
@@ -32,7 +32,7 @@ public class Pucharse {
     @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "suscription_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_pucharse_suscription"))
-    private Suscription suscription;
+    private Subscription suscription;
 
     @ManyToOne
     @JoinColumn(name = "donation_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_pucharse_donation"))

--- a/src/main/java/com/Profpost/model/entity/Subscription.java
+++ b/src/main/java/com/Profpost/model/entity/Subscription.java
@@ -6,20 +6,30 @@ import java.time.LocalDateTime;
 
 @Data
 @Entity
-@Table(name = "suscription")
+@Table(name = "subscription")
 
-public class Suscription {
+public class Subscription {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "start_date")
+    private LocalDateTime starDate;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
 
     @Enumerated(EnumType.STRING)
     private SubscriptionState subscriptionState;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "creator_id")
+    private User creator;
 }

--- a/src/main/java/com/Profpost/repository/SubscriptionRepository.java
+++ b/src/main/java/com/Profpost/repository/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.Profpost.repository;
+
+import com.Profpost.model.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Integer> {
+}

--- a/src/main/java/com/Profpost/service/SubscriptionService.java
+++ b/src/main/java/com/Profpost/service/SubscriptionService.java
@@ -1,0 +1,9 @@
+package com.Profpost.service;
+
+import com.Profpost.dto.SubscriptionDTO;
+import com.Profpost.dto.SubscriptionResponseDTO;
+
+public interface SubscriptionService {
+    SubscriptionResponseDTO subscribe(SubscriptionDTO subscriptionDTO);
+    SubscriptionResponseDTO unsubscribe(Integer subscriptionId);
+}

--- a/src/main/java/com/Profpost/service/impl/SubscriptionServiceImpl.java
+++ b/src/main/java/com/Profpost/service/impl/SubscriptionServiceImpl.java
@@ -1,0 +1,62 @@
+package com.Profpost.service.impl;
+
+import com.Profpost.dto.SubscriptionDTO;
+import com.Profpost.dto.SubscriptionResponseDTO;
+import com.Profpost.model.entity.Subscription;
+import com.Profpost.model.entity.User;
+import com.Profpost.model.enums.SubscriptionState;
+import com.Profpost.repository.SubscriptionRepository;
+import com.Profpost.repository.UserRepository;
+import com.Profpost.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.temporal.TemporalAdjusters;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class SubscriptionServiceImpl implements SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public SubscriptionResponseDTO subscribe(SubscriptionDTO subscriptionDTO){
+        User user = userRepository.findById(subscriptionDTO.getUser_id())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Subscription subscription = new Subscription();
+        subscription.setStarDate(LocalDateTime.now());
+        subscription.setSubscriptionState(SubscriptionState.SUBSCRIBE);
+
+        subscription = subscriptionRepository.save(subscription);
+
+        SubscriptionResponseDTO response = new SubscriptionResponseDTO();
+        response.setSubscriptionId(subscription.getId());
+        response.setUserId(subscriptionDTO.getUser_id());
+        response.setCreatorId(subscriptionDTO.getCreator_id());
+        response.setStatus("Success");
+        response.setMessage("Subscription created successfully!");
+
+        return response;
+    }
+
+    @Transactional
+    @Override
+    public SubscriptionResponseDTO unsubscribe(Integer subscriptionId) {
+        Subscription subscription = subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new RuntimeException("Subscription not found"));
+
+        subscription.setSubscriptionState(SubscriptionState.NON_SUBSCRIBE);
+        subscription.setEndDate(LocalDateTime.now().with(TemporalAdjusters.lastDayOfMonth()));
+
+        SubscriptionResponseDTO response = new SubscriptionResponseDTO();
+        response.setSubscriptionId(subscriptionId);
+        response.setStatus("Success");
+        response.setMessage("Subscription deleted successfully!");
+
+        return response;
+    }
+}


### PR DESCRIPTION
Este pull request añade la implementación completa de las suscripciones donde los usuarios lectores podrán suscribirse a usuarios creadores.

### *Cambios Realizados*
Se añadió el repositorio `SubscriptionRepository ` con métodos básicos de CRUD.
Se creó el servicio `SubscriptionService ` y SubscriptionServiceImpl con la lógica para suscribirse y dejar de suscribirse.
Se implementó el controlador SuscriptionController con endpoints REST para las operaciones Post y Delete.
Se implementó un DTO SubscriptionDTO y SubscriptionResponseDTO donde se unen los id's del usuario y del creador y devuelve la suscripción.
Se realizaron las pruebas para verificar la funcionalidad de las suscripciones mediante Postman.