### PR TITLE
feat(backend): Asignar rol READER por defecto al crear usuarios y permitir actualización a CREATOR

### DIFF
--- a/src/main/java/com/Profpost/api/AuthController.java
+++ b/src/main/java/com/Profpost/api/AuthController.java
@@ -33,5 +33,4 @@ public class AuthController {
         User newUser = userService.registerUser(user);
         return new ResponseEntity<>(newUser, HttpStatus.CREATED);
     }
-
 }

--- a/src/main/java/com/Profpost/dto/UserDTO.java
+++ b/src/main/java/com/Profpost/dto/UserDTO.java
@@ -1,0 +1,4 @@
+package com.Profpost.dto;
+
+public class UserDTO {
+}

--- a/src/main/java/com/Profpost/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/Profpost/service/impl/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.Profpost.service.impl;
 
 import com.Profpost.model.entity.User;
+import com.Profpost.model.enums.Role;
 import com.Profpost.repository.UserRepository;
 import com.Profpost.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -38,12 +39,19 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public User update(Integer id, User updatedUser) {
+
         User userFromDb = findById(id);
+
         userFromDb.setName(updatedUser.getName());
         userFromDb.setEmail(updatedUser.getEmail());
         userFromDb.setPassword(updatedUser.getPassword());
         userFromDb.setBiography(updatedUser.getBiography());
         userFromDb.setUpdatedAt(LocalDateTime.now());
+
+        if (updatedUser.getRole() == Role.CREATOR){
+            userFromDb.setRole(Role.CREATOR);
+        }
+
         return userRepository.save(userFromDb);
     }
 
@@ -60,6 +68,7 @@ public class UserServiceImpl implements UserService {
         if(userRepository.existsByEmail(user.getEmail())) {
             throw new RuntimeException("Email already exists");
         }
+        user.setRole(Role.READER);
         user.setCreatedAt(LocalDateTime.now());
 
         return userRepository.save(user);


### PR DESCRIPTION
Se implementó la funcionalidad para que todos los usuarios creados tengan asignado el rol READER por defecto, independientemente del rol enviado en el RequestBody.
Se agregó la validación que permite cambiar el rol del usuario a CREATOR solo a través del endpoint de actualización.
Esto garantiza que los usuarios no puedan auto-asignarse el rol de CREATOR durante el registro, mejorando la seguridad del sistema.