### PR TITLE
Implementacion para agregar una publicacion a una playlist

### DIFF
--- a/src/main/java/com/Profpost/api/PlaylistController.java
+++ b/src/main/java/com/Profpost/api/PlaylistController.java
@@ -1,6 +1,6 @@
 package com.Profpost.api;
 
-import org.springframework.ui.Model;
+import com.Profpost.dto.PublicationInPlaylistDTO;
 import com.Profpost.dto.PlaylistDTO;
 import com.Profpost.model.entity.Publication;
 import com.Profpost.service.PlaylistService;
@@ -48,9 +48,9 @@ public class PlaylistController {
     }
 
     @GetMapping("/{playlistId}/publications")
-    public ResponseEntity<List<Publication>> getPublicationByPlaylist(@PathVariable Integer playlistId) {
-        List<Publication> publication = playlistService.getPublicationByPlaylistId(playlistId);
-        return ResponseEntity.ok(publication);
+    public ResponseEntity<List<PublicationInPlaylistDTO>> getPublicationsForPlaylist(@PathVariable Integer playlistId) {
+        List<PublicationInPlaylistDTO> publications = playlistService.getPublicationsForPlaylist(playlistId);
+        return ResponseEntity.ok(publications);
     }
 
     @PostMapping("/add/publication")
@@ -60,18 +60,16 @@ public class PlaylistController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/{playlistId}/publications/{publicationsId}")
-    public ResponseEntity<Void> removePublicationFromPlaylist(@PathVariable Integer playlistId, @PathVariable Integer publicationId) {
+    @DeleteMapping("/{playlistId}/publications/{publicationId}")
+    public void removePublicationFromPlaylist(
+            @PathVariable Integer playlistId,
+            @PathVariable Integer publicationId) {
         playlistService.removePublicationFromPlaylist(playlistId, publicationId);
-        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/my-playlists")
     public ResponseEntity<List<PlaylistDTO>> getPlaylistsForUser() {
-        // Obtener las playlists asociadas al usuario autenticado
         List<PlaylistDTO> playlists = playlistService.findPlaylistsByUser();
-
-        // Retornar las playlists en formato JSON
         return ResponseEntity.ok(playlists);
     }
 }

--- a/src/main/java/com/Profpost/dto/PublicationInPlaylistDTO.java
+++ b/src/main/java/com/Profpost/dto/PublicationInPlaylistDTO.java
@@ -1,0 +1,12 @@
+package com.Profpost.dto;
+
+import lombok.Data;
+
+@Data
+public class PublicationInPlaylistDTO {
+    private Integer id;
+    private String title;
+    private String content;
+    private String video_url;
+    private String filePath;
+}

--- a/src/main/java/com/Profpost/model/entity/Playlist.java
+++ b/src/main/java/com/Profpost/model/entity/Playlist.java
@@ -1,6 +1,6 @@
 package com.Profpost.model.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Data;
 import java.time.LocalDateTime;
@@ -14,7 +14,7 @@ public class Playlist {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(name = "created_at", nullable = false)
@@ -23,8 +23,13 @@ public class Playlist {
     @Column(name = "updated_at")
     private LocalDateTime updated_at;
 
-    @JsonIgnore
-    @OneToMany(mappedBy = "playlist")
+    @JsonManagedReference
+    @ManyToMany
+    @JoinTable(
+            name = "playlist_publication", // Tabla intermedia
+            joinColumns = @JoinColumn(name = "playlist_id"),
+            inverseJoinColumns = @JoinColumn(name = "publication_id")
+    )
     private List<Publication> publications;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/Profpost/model/entity/Publication.java
+++ b/src/main/java/com/Profpost/model/entity/Publication.java
@@ -1,5 +1,6 @@
 package com.Profpost.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -52,7 +53,7 @@ public class Publication {
     @JsonIgnore
     private Creator creator;
 
-    @JsonIgnore
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "playlist_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_publication_playlist"))
     private Playlist playlist;

--- a/src/main/java/com/Profpost/service/PlaylistService.java
+++ b/src/main/java/com/Profpost/service/PlaylistService.java
@@ -1,6 +1,7 @@
 package com.Profpost.service;
 
 import com.Profpost.dto.PlaylistDTO;
+import com.Profpost.dto.PublicationInPlaylistDTO;
 import com.Profpost.model.entity.Publication;
 
 import java.util.List;
@@ -14,12 +15,12 @@ public interface PlaylistService {
 
     void delete(Integer id);
 
-    List<Publication> getPublicationByPlaylistId(Integer playlistId);
+    public List<PublicationInPlaylistDTO> getPublicationsForPlaylist(Integer playlistId);
 
     Publication addPublicationToPlaylist(Integer playlistId, Integer publicationId);
 
     void removePublicationFromPlaylist(Integer playlistId, Integer publicationId);
 
-    // Nuevo método para obtener las playlists del usuario autenticado
     List<PlaylistDTO> findPlaylistsByUser();
 }
+


### PR DESCRIPTION
### **CAMBIOS REALIZADOS**

- Agregado un nuevo método para obtener las publicaciones de una `playlist `específica. En lugar de devolver un List<Publication>, ahora devuelve un List<PublicationInPlaylistDTO>
-  Implementado un método para agregar publicaciones a una playlist con @PostMapping y usando @RequestParam para recibir el `publicationId `y `playlistId`.
- Mejorado este método para devolver ResponseEntity.noContent().build() después de eliminar una publicación de una playlist. Esto es más apropiado porque significa que la solicitud fue procesada con éxito.